### PR TITLE
Debug: enable show_full_output for AI review

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -124,6 +124,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.AI_CODE_REVIEW_ANTHROPIC_API_KEY }}
+          show_full_output: true
           prompt: |
             You are a senior code reviewer for WooCommerce extensions.
             Review the PR diff for this repository.


### PR DESCRIPTION
Temporary: enables full Claude output logging to diagnose why AI reviews complete successfully but post no comments (13 permission denials observed).

Revert after debugging.