### PR TITLE
Fix allowedTools patterns for AI code review

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -124,7 +124,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.AI_CODE_REVIEW_ANTHROPIC_API_KEY }}
-          show_full_output: true
           prompt: |
             You are a senior code reviewer for WooCommerce extensions.
             Review the PR diff for this repository.
@@ -302,4 +301,4 @@ jobs:
 
           claude_args: >
             --model ${{ inputs.model || 'claude-opus-4-6' }}
-            --allowedTools "Read(/home/runner/work/**),Glob,Grep,Write(ai_review_payload.json),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:repos/*/pulls/*/reviews*),Bash(gh api:repos/*/pulls/*/comments*),Bash(git show:*),Bash(git diff:*),Bash(git log:*),Bash(git blame:*),Bash(git rev-parse:*),Bash(git ls-files:*),Bash(git grep:*)"
+            --allowedTools "Read(/home/runner/work/**),Glob,Grep,Write,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git show:*),Bash(git diff:*),Bash(git log:*),Bash(git blame:*),Bash(git rev-parse:*),Bash(git ls-files:*),Bash(git grep:*)"


### PR DESCRIPTION
Fixes the permission denial issue causing AI reviews to complete without posting comments (13 permission denials observed).

The Bash() patterns used colon-prefixed paths like `Bash(gh api:repos/*/pulls/*/reviews*)` which don't work because the `:*` shorthand is only recognized at the very end of the pattern. Mid-string wildcards with colons are treated as literal characters.

Switches to `Bash(gh api:*)` and `Write` (unrestricted), matching the patterns used by woocommerce/woocommerce's [backwards-compatibility-review.yml](https://github.com/woocommerce/woocommerce/blob/trunk/.github/workflows/backwards-compatibility-review.yml#L116) which runs on all PRs to the woocommerce monorepo.

Also removes the temporary `show_full_output` debug flag.