### PR TITLE
Switch to team-based membership check

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -22,7 +22,7 @@ on:
       AI_CODE_REVIEW_ANTHROPIC_API_KEY:
         required: true
       ORG_MEMBERS_READ_TOKEN:
-        required: false
+        required: true
 
 jobs:
   ai-review:
@@ -55,7 +55,7 @@ jobs:
           done
           echo "is_member=false" >> "$GITHUB_OUTPUT"
         env:
-          GH_TOKEN: ${{ secrets.ORG_MEMBERS_READ_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.ORG_MEMBERS_READ_TOKEN }}
           ALLOWED_TEAMS: ${{ inputs.allowed_teams || 'happiness-engineers,qualityops' }}
           PR_USER: ${{ github.event.pull_request.user.login }}
 

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -3,11 +3,11 @@ name: AI Code Review (Reusable)
 on:
   workflow_call:
     inputs:
-      allowed_users:
-        description: 'JSON array of GitHub usernames allowed to trigger reviews'
+      allowed_teams:
+        description: 'Comma-separated GitHub team slugs in the woocommerce org to check membership against'
         required: false
         type: string
-        default: '["mahangu","anant1811"]'
+        default: 'happiness-engineers,qualityops'
       model:
         description: 'Claude model to use'
         required: false
@@ -21,6 +21,8 @@ on:
     secrets:
       AI_CODE_REVIEW_ANTHROPIC_API_KEY:
         required: true
+      ORG_MEMBERS_READ_TOKEN:
+        required: false
 
 jobs:
   ai-review:
@@ -39,16 +41,22 @@ jobs:
       id-token: write
 
     steps:
-      - name: Check allowed users
+      - name: Check team membership
         id: check-team
         run: |
-          ALLOWED='${{ inputs.allowed_users || '["mahangu","anant1811"]' }}'
-          if echo "$ALLOWED" | grep -q "\"${PR_USER}\""; then
-            echo "is_member=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "is_member=false" >> "$GITHUB_OUTPUT"
-          fi
+          IFS=',' read -ra TEAMS <<< "$ALLOWED_TEAMS"
+          for TEAM in "${TEAMS[@]}"; do
+            TEAM=$(echo "$TEAM" | xargs)
+            STATUS=$(gh api "orgs/woocommerce/teams/${TEAM}/memberships/${PR_USER}" --jq '.state' 2>/dev/null || echo "not_found")
+            if [[ "$STATUS" == "active" ]]; then
+              echo "is_member=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+          echo "is_member=false" >> "$GITHUB_OUTPUT"
         env:
+          GH_TOKEN: ${{ secrets.ORG_MEMBERS_READ_TOKEN || github.token }}
+          ALLOWED_TEAMS: ${{ inputs.allowed_teams || 'happiness-engineers,qualityops' }}
           PR_USER: ${{ github.event.pull_request.user.login }}
 
       - name: Checkout repository


### PR DESCRIPTION
Replaces hardcoded username allowlist with team membership check via the GitHub API.

Uses the ORG_MEMBERS_READ_TOKEN org secret (fine-grained PAT with Members:Read org permission) to query happiness-engineers and qualityops team membership.

Callers need to either pass ORG_MEMBERS_READ_TOKEN explicitly or use secrets: inherit.

The csv-import-suite caller workflow will need a follow-up PR to switch from explicit secrets to secrets: inherit.