### PR TITLE
Add automatticians team to default AI review allowlist

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -7,7 +7,7 @@ on:
         description: 'Comma-separated GitHub team slugs in the woocommerce org to check membership against'
         required: false
         type: string
-        default: 'happiness-engineers,qualityops'
+        default: 'automatticians,happiness-engineers,qualityops'
       model:
         description: 'Claude model to use'
         required: false
@@ -56,7 +56,7 @@ jobs:
           echo "is_member=false" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.ORG_MEMBERS_READ_TOKEN }}
-          ALLOWED_TEAMS: ${{ inputs.allowed_teams || 'happiness-engineers,qualityops' }}
+          ALLOWED_TEAMS: ${{ inputs.allowed_teams || 'automatticians,happiness-engineers,qualityops' }}
           PR_USER: ${{ github.event.pull_request.user.login }}
 
       - name: Checkout repository


### PR DESCRIPTION
# Change

Adds `automatticians` to the default `allowed_teams` list in the reusable AI review workflow, alongside `happiness-engineers` and `qualityops`.

# Why

Requested in Slack by @PanosSynetos and @nerrad: https://a8c.slack.com/archives/C08TJTPLABW/p1776851288848329

AI review did not run on https://github.com/woocommerce/woocommerce-bookings/pull/4264 because the PR author (@PanosSynetos ) is an Automattician but not a member of happiness-engineers or qualityops. 

@nerrad  confirmed there is no problem using the automatticians team to gate review on repos that have opted in via their caller workflow.

The gate still requires each repo to explicitly enable the review (the reusable workflow is called from a per-repo caller). Adding the team only affects repos that already opted in.

# Scope

- Updates the workflow default. Callers that pass a custom \`allowed_teams\` input are unaffected.
- No behaviour change on PRs from authors who are already in happiness-engineers or qualityops.

Linear: QAO-398