### PR TITLE
Remove deprecated allowed_teams input and ORG_MEMBERS_READ_TOKEN secret

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -3,11 +3,6 @@ name: AI Code Review (Reusable)
 on:
   workflow_call:
     inputs:
-      allowed_teams:
-        description: 'Deprecated. Team membership is no longer used for gating; AI review runs for any author with write/admin on the calling repo. Kept temporarily so existing callers do not hard-break; remove after the 17 pilot callers stop passing it.'
-        required: false
-        type: string
-        default: ''
       model:
         description: 'Claude model to use'
         required: false
@@ -21,9 +16,6 @@ on:
     secrets:
       AI_CODE_REVIEW_ANTHROPIC_API_KEY:
         required: true
-      ORG_MEMBERS_READ_TOKEN:
-        description: 'Deprecated. No longer used; write-permission gating uses the default GITHUB_TOKEN. Kept temporarily so existing callers do not hard-break; remove after the 17 pilot callers stop passing it.'
-        required: false
 
 jobs:
   # Caller-org guard. Reject callers outside the allowed orgs before any


### PR DESCRIPTION
# Change

Drops two dead declarations from the reusable workflow's `workflow_call:` surface:

- `allowed_teams` input (was deprecated in #13 when we pivoted to write-permission gating)
- `ORG_MEMBERS_READ_TOKEN` secret (same PR; the default `GITHUB_TOKEN` now handles collaborator-permission lookups)

Both were kept as soft-break safety during caller cleanup.

# Safe because

QAO-411 removed the passthrough from all 17 callers. Verified with `gh search code 'ORG_MEMBERS_READ_TOKEN path:.github/workflows/ai-code-review.yml'` — zero matches.

# Follow-ups after this lands

- Revoke the fine-grained PAT on `woocommercebot`'s GitHub account

Linear: QAO-412