### PR TITLE
Drop unused id-token: write permission

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -70,7 +70,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      id-token: write
 
     steps:
       # Author gating: allow PRs only from users with write or admin on the


### PR DESCRIPTION
Tightening the `ai-review` job's `permissions:` to the minimum it actually uses. The workflow authenticates via `AI_CODE_REVIEW_ANTHROPIC_API_KEY`, not OIDC.

Linear: QAO-421