### PR TITLE
Pin actions/checkout and claude-code-action to SHAs

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.check-team.outputs.is_member == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -178,7 +178,7 @@ jobs:
         if: |
           steps.check-team.outputs.is_member == 'true' &&
           steps.followup.outputs.skip != 'true'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1.0.107
         with:
           anthropic_api_key: ${{ secrets.AI_CODE_REVIEW_ANTHROPIC_API_KEY }}
           prompt: |


### PR DESCRIPTION
Pin the two third-party actions in `ai-code-review.yml` to immutable SHAs instead of floating tags.

## Changes

* `actions/checkout@v4` → `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
* `anthropics/claude-code-action@v1` → `anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1.0.107`

## Why

This workflow runs with access to `secrets.AI_CODE_REVIEW_ANTHROPIC_API_KEY` and posts review comments via `pull-requests: write`. Floating `@v4` / `@v1` would let any new release tagged on those refs run with our token and key. SHA-pinning locks each upgrade to a deliberate review.

## Behavior change

None. Both SHAs are what the floating `@v4` / `@v1` tags currently resolve to (verified via two independent agents resolving each tag). Callers see no observable difference until the next time we deliberately bump.

## Verification

```
$ gh api repos/actions/checkout/git/refs/tags/v4 --jq '.object.sha'
34e114876b0b11c390a56381ad16ebd13914f8d5

$ gh api repos/anthropics/claude-code-action/git/refs/tags/v1 | gh api repos/anthropics/claude-code-action/git/tags/$(jq -r '.object.sha') --jq '.object.sha'
567fe954a4527e81f132d87d1bdbcc94f7737434
```