### PR TITLE
Skip AI review on AGENTS.md/CLAUDE.md edits; harden checkout

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -108,11 +108,33 @@ jobs:
           PR_USER: ${{ github.event.pull_request.user.login }}
           PR_USER_TYPE: ${{ github.event.pull_request.user.type }}
 
+      # AGENTS.md / CLAUDE.md are bot instructions; skip review if a PR edits them
+      # so the bot doesn't review under guidance the PR itself is modifying.
+      - name: Skip AI review on trusted-instruction file edits
+        if: steps.check-team.outputs.is_member == 'true'
+        id: trusted_files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          FILES=$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)
+          if echo "$FILES" | grep -qiE '(^|/)(AGENTS|CLAUDE)\.md$'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
+              "AI review skipped: this PR modifies \`AGENTS.md\` or \`CLAUDE.md\` files, which the review bot reads as instructions. Edits to these files require human review."
+            exit 1
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
         if: steps.check-team.outputs.is_member == 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Detect follow-up review
         if: steps.check-team.outputs.is_member == 'true'
@@ -177,7 +199,8 @@ jobs:
       - name: AI Code Review
         if: |
           steps.check-team.outputs.is_member == 'true' &&
-          steps.followup.outputs.skip != 'true'
+          steps.followup.outputs.skip != 'true' &&
+          steps.trusted_files.outputs.skip == 'false'
         uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1.0.107
         with:
           anthropic_api_key: ${{ secrets.AI_CODE_REVIEW_ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Proposed Changes

* Skip AI review when a PR modifies any `AGENTS.md` or `CLAUDE.md` file. Post a comment explaining why human review is needed and fail the workflow so the PR shows a red X.
* Add `persist-credentials: false` to the checkout step so the workflow `GITHUB_TOKEN` is not left in `.git/config` for any subsequent step or tool to read.

## Why

* `AGENTS.md` and `CLAUDE.md` are loaded by the review bot as instructions; a PR shouldn't be self-reviewed against guidance it's modifying. The action's existing [`restoreConfigFromBase`](https://github.com/anthropics/claude-code-action/blob/main/src/github/operations/restore-config.ts) defense covers only root `CLAUDE.md` and `.claude/`; `AGENTS.md` and nested `CLAUDE.md` are outside its `SENSITIVE_PATHS` list. With Woo's default checkout (no `ref:` pin) the working tree contains PR head content, so the bot's `Read` of `@AGENTS.md` would resolve PR-controlled instructions.
* Failing the workflow on skip gives reviewers a visible red X in the checks panel rather than a silent pass-through.
* `persist-credentials: false` is a no-op in normal operation but closes a class of accidental token leak through later steps.

## Notes

* Item placement: skip step runs after the author-write-access gate and before `Detect follow-up review`, so we short-circuit cleanly without computing followup state when skipping.
* The skip step propagates to all 17 satellite repos automatically via the `@trunk` `workflow_call` invocation.
* `ref: github.event.repository.default_branch` (Calypso's pattern) is intentionally NOT applied here because it would break the tier1/tier2 followup logic which uses `HEAD` as the PR ref. The skip guard alone is sufficient to neutralize the `AGENTS.md` vector.

## Testing Instructions

* Workflow changes can't be exercised on the modifying PR (OIDC). After merge, verify on follow-up PRs in any satellite repo:
    * A satellite PR touching `AGENTS.md` or `CLAUDE.md` should get a skip comment plus a failed AI review check.
    * A satellite PR not touching those files should review normally (including the existing tier1/tier2 followup behavior on subsequent pushes).
