### PR TITLE
Skip AI review on synchronize events

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -58,6 +58,7 @@ jobs:
   ai-review:
     needs: guard
     if: |
+      github.event.action != 'synchronize' &&
       (github.repository_owner == 'woocommerce' || github.repository_owner == 'mailpoet') &&
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo != null &&


### PR DESCRIPTION
## Summary

Skip the `ai-review` job when `github.event.action == 'synchronize'` so the bot stops re-running on every push.

## Why

The reusable fires on `[opened, synchronize, ready_for_review, reopened]` and re-runs the review on every commit during the ready-for-review state. This burns Anthropic tokens on near-identical reviews and clutters PRs with repeated comments.

The existing job already gates on `pull_request.draft == false`, so drafts are quiet. This change extends that quiet behaviour to `synchronize` events on ready PRs. Mental model after the change: AI review runs on PR open and on draft → ready transitions, not on every push.

## Behaviour after the change

- PR opened: review runs (unchanged).
- Push commits to a draft: review skipped (unchanged, gated by draft check).
- Push commits to a ready PR: workflow spins up, ai-review job is skipped, no token cost (new).
- Convert to draft, mark ready: fires \`ready_for_review\`, review runs. This is the manual re-run mechanism.

## Test plan

- [ ] Open a draft PR in a Woo plugin repo: confirm no review runs.
- [ ] Mark ready: confirm review runs.
- [ ] Push commits while ready: confirm workflow runs but ai-review job is skipped.
- [ ] Toggle back to draft and back to ready: confirm review re-runs.

Refs: QAO-429