### PR TITLE
ai-review: add @claude review / @claude /review comment trigger (QAO-430)

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -73,7 +73,7 @@ jobs:
       # an in-flight pull_request-triggered first review (and vice versa).
       # NOTE: concurrency expressions are evaluated before the job's env
       # block materializes, so we inline the PR-number shim instead of
-      # using ${{ env.PR_NUMBER }} (which would resolve to empty here).
+      # using ${{ github.event.pull_request.number || github.event.issue.number }} (which would resolve to empty here).
       group: ai-review-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
@@ -82,12 +82,6 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    env:
-      # Event-shape shim: lift PR identifiers once so steps and the inline
-      # prompt below stay readable.
-      PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-      PR_AUTHOR: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
-      REPO: ${{ github.repository }}
 
     steps:
       # Trigger validation. issue_comment fires on every comment in the repo;
@@ -132,19 +126,20 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: |
           set -euo pipefail
           if [ -n "$PR_HEAD_REPO" ]; then
             HEAD_REPO="$PR_HEAD_REPO"
           else
-            HEAD_REPO=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+            HEAD_REPO=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
               --json headRepositoryOwner,headRepository \
               --jq 'if .headRepository == null or .headRepositoryOwner == null
                     then "DELETED-OR-UNKNOWN"
                     else "\(.headRepositoryOwner.login)/\(.headRepository.name)" end')
           fi
-          if [ "$HEAD_REPO" != "$REPO" ]; then
-            echo "::error::Fork PR rejected. Head repo: $HEAD_REPO, base: $REPO."
+          if [ "$HEAD_REPO" != "$GITHUB_REPOSITORY" ]; then
+            echo "::error::Fork PR rejected. Head repo: $HEAD_REPO, base: $GITHUB_REPOSITORY."
             exit 1
           fi
 
@@ -173,7 +168,7 @@ jobs:
             echo "is_member=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          PR_PERM=$(gh api "repos/${REPO}/collaborators/${PR_AUTHOR}/permission" --jq '.permission' 2>${RUNNER_TEMP}/gh.err || echo "none")
+          PR_PERM=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${PR_AUTHOR}/permission" --jq '.permission' 2>${RUNNER_TEMP}/gh.err || echo "none")
           PR_PERM=${PR_PERM:-none}
           case "$PR_PERM" in
             admin|write) ;;
@@ -192,7 +187,7 @@ jobs:
               echo "is_member=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            SENDER_PERM=$(gh api "repos/${REPO}/collaborators/${SENDER}/permission" --jq '.permission' 2>${RUNNER_TEMP}/gh.err || echo "none")
+            SENDER_PERM=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${SENDER}/permission" --jq '.permission' 2>${RUNNER_TEMP}/gh.err || echo "none")
             SENDER_PERM=${SENDER_PERM:-none}
             case "$SENDER_PERM" in
               admin|write) ;;
@@ -209,6 +204,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
           PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type || github.event.issue.user.type }}
           SENDER: ${{ github.event.comment.user.login }}
           SENDER_TYPE: ${{ github.event.comment.user.type }}
@@ -220,6 +216,8 @@ jobs:
         id: trusted_files
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           FILES=$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)
@@ -363,6 +361,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           BEFORE_SHA: ${{ github.event.before }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
 
       - name: AI Code Review
         if: |
@@ -377,7 +378,7 @@ jobs:
             Review the PR diff for this repository.
 
             REPO: ${{ github.repository }}
-            PR: #${{ env.PR_NUMBER }}
+            PR: #${{ github.event.pull_request.number || github.event.issue.number }}
             REVIEW_TYPE: ${{ steps.followup.outputs.review_type }}
 
             OBJECTIVE
@@ -395,7 +396,7 @@ jobs:
             - Only post inline comments for NEW issues
 
             If REVIEW_TYPE is "tier2" (rebase or no before SHA):
-            - Get the full PR diff using: gh pr diff ${{ env.PR_NUMBER }}
+            - Get the full PR diff using: gh pr diff ${{ github.event.pull_request.number || github.event.issue.number }}
             - Read "${RUNNER_TEMP}/previous_review.txt" for the previous review
             - Read "${RUNNER_TEMP}/author-replies.md" for author replies posted since the previous review
             - Produce a per-issue reconciliation (see PER-ISSUE RECONCILIATION below). Do not re-derive findings from a fresh read of the diff.
@@ -403,7 +404,7 @@ jobs:
 
             If REVIEW_TYPE is "first":
             - This is the first review. Do a full review of the PR diff.
-            - Get the PR diff using: gh pr diff ${{ env.PR_NUMBER }}
+            - Get the PR diff using: gh pr diff ${{ github.event.pull_request.number || github.event.issue.number }}
 
             PER-ISSUE RECONCILIATION (tier1/tier2 only)
             Enumerate EACH prior issue from the previous review. Don't summarize across them. Mark each with one of:
@@ -444,7 +445,7 @@ jobs:
 
             HUMAN REVIEW INVESTIGATION
             Before analyzing the diff, read existing human and bot review comments on this PR:
-               gh api "repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}/reviews?per_page=100" --paginate
+               gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number || github.event.issue.number }}/reviews?per_page=100" --paginate
             For each concern raised by a human or bot reviewer (excluding your own previous AI reviews):
             - Investigate it using the codebase: trace code paths, check how affected functions are used, verify the concern with evidence
             - Include your findings in your review: confirm, refute, or expand on each concern with specific code references
@@ -456,7 +457,7 @@ jobs:
 
             For first reviews:
             1. Fetch ALL existing review comments on this PR:
-               gh api "repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}/comments?per_page=100" --paginate
+               gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number || github.event.issue.number }}/comments?per_page=100" --paginate
             2. Filter to comments from "claude[bot]" that contain "AI Code Review"
             3. Build a list of already-covered concerns: for each existing comment, note the file path, line number, and the issue described
             4. When you find a potential issue, check your list - if an existing comment ALREADY covers the same concern on the same file (same or nearby lines within 5 lines), SKIP it
@@ -469,7 +470,7 @@ jobs:
             Post ALL comments as a SINGLE review to avoid spamming notifications.
 
             Step 1: Get the latest commit SHA:
-               gh api "repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}" --jq '.head.sha'
+               gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number || github.event.issue.number }}" --jq '.head.sha'
 
             Step 2: Use the Write tool to create a JSON file at ./ai_review_payload.json.
             Replace {{COMMIT_SHA}} with the SHA from Step 1.
@@ -495,7 +496,7 @@ jobs:
             For {{HOUSEKEEPING}}: render the trailing PR-housekeeping block (see PR HOUSEKEEPING below). Empty string if there is nothing to put in it.
 
             Step 3: Submit the review using the file as input:
-               gh api "repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}/reviews" -X POST --input ai_review_payload.json
+               gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number || github.event.issue.number }}/reviews" -X POST --input ai_review_payload.json
 
             ALWAYS post a review, even if no issues are found. If the code looks good, submit a review with an empty comments array and a summary like "AI Code Review - No issues found. The changes look good."
 
@@ -603,7 +604,7 @@ jobs:
             6. For each potential issue, check if already covered (skip if so)
             7. Build the {{SUMMARY}} (per-issue reconciliation lines for tier1/tier2, or counts for first) and the {{HOUSEKEEPING}} block (or empty)
             8. Use the Write tool to create ./ai_review_payload.json (include the HTML marker comment, the footer sentinel, and the cheat-sheet block exactly as shown)
-            9. Submit: gh api "repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}/reviews" -X POST --input ai_review_payload.json
+            9. Submit: gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number || github.event.issue.number }}/reviews" -X POST --input ai_review_payload.json
 
           claude_args: >
             --model ${{ inputs.model || 'claude-opus-4-6' }}

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -62,6 +62,7 @@ jobs:
       (
         (github.event_name == 'pull_request' &&
          github.event.action != 'synchronize' &&
+         github.event.pull_request.draft == false &&
          github.event.pull_request.head.repo != null &&
          github.event.pull_request.head.repo.full_name == github.repository) ||
         (github.event_name == 'issue_comment' &&

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -69,11 +69,7 @@ jobs:
          github.event.issue.state == 'open')
       )
     concurrency:
-      # Namespace by event so a comment-triggered re-review does not cancel
-      # an in-flight pull_request-triggered first review (and vice versa).
-      # NOTE: concurrency expressions are evaluated before the job's env
-      # block materializes, so we inline the PR-number shim instead of
-      # using ${{ github.event.pull_request.number || github.event.issue.number }} (which would resolve to empty here).
+      # Per-event namespace so a comment trigger does not cancel an in-flight first review.
       group: ai-review-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
@@ -84,10 +80,8 @@ jobs:
       id-token: write
 
     steps:
-      # Trigger validation. issue_comment fires on every comment in the repo;
-      # only proceed if the body matches the bot trigger and the issue is a PR.
-      # COMMENT_BODY comes from event metadata, never from PR HEAD content,
-      # so it is safe to grep against here.
+      # Gate issue_comment runs to PR comments matching the bot trigger.
+      # COMMENT_BODY is event metadata, safe to grep here.
       - name: Validate trigger
         id: trigger
         env:
@@ -102,17 +96,7 @@ jobs:
               echo "skip=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            # Strip CRLF so Windows-clipboard / GitHub-mobile bodies match.
-            # Pattern: line starts with optional whitespace, then `@claude`,
-            # then whitespace, then optional `/`, then `review`, then
-            # end-of-line / whitespace / punctuation.
-            # Accepted: `@claude review`, `@claude /review` (matches the
-            # wp-calypso bot convention), `@claude review.`,
-            # `@claude /review please`.
-            # Rejected: `@claude reviewer` (next char must be space/punct/EOL),
-            # `## @claude review` / `- @claude review` (markdown prefixes are
-            # punct, not space, before `@`), bare `review`, mid-line forms
-            # like `please @claude review this`.
+            # Accept `@claude review` and `@claude /review` (line-anchored, optional trailing punctuation).
             CLEAN_BODY=${COMMENT_BODY//$'\r'/}
             if ! printf '%s\n' "$CLEAN_BODY" | grep -qiE '^[[:space:]]*@claude[[:space:]]+/?review([[:space:]]|[[:punct:]]|$)'; then
               echo "Comment did not match @claude review or @claude /review trigger; skipping."
@@ -122,10 +106,7 @@ jobs:
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
-      # Defense-in-depth fork rejection. The job-level if: rejects forks on
-      # the pull_request path; issue_comment payloads do not include
-      # head.repo, so we look it up via gh pr view and compare here. exit 1
-      # fails the job before any secret-using model invocation.
+      # Fork reject. issue_comment payloads lack head.repo, so look it up.
       - name: Reject fork PRs
         if: steps.trigger.outputs.skip != 'true'
         env:
@@ -148,19 +129,9 @@ jobs:
             exit 1
           fi
 
-      # Author and sender gating: allow runs only when the PR author has
-      # write or admin on the calling repo, AND on issue_comment events,
-      # the comment sender also has write or admin. Both checks are needed
-      # because issue_comment fires from the default branch with secrets in
-      # scope, so any commenter on a PR could otherwise trigger a review.
-      # Bots are rejected via the user.type field.
-      #
-      # The permission endpoint returns only admin|write|read|none (maintain
-      # collapses to write, triage to read). It returns the highest computed
-      # access across direct/team/org/enterprise grants.
-      #
-      # Docs:
-      # - https://docs.github.com/en/rest/collaborators/collaborators#get-repository-permissions-for-a-user
+      # PR author and (on issue_comment) comment sender must both have admin|write.
+      # Permission API returns admin|write|read|none.
+      # https://docs.github.com/en/rest/collaborators/collaborators#get-repository-permissions-for-a-user
       - name: Check write access
         id: check-team
         if: steps.trigger.outputs.skip != 'true'

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -58,13 +58,23 @@ jobs:
   ai-review:
     needs: guard
     if: |
-      github.event.action != 'synchronize' &&
       (github.repository_owner == 'woocommerce' || github.repository_owner == 'mailpoet') &&
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo != null &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      (
+        (github.event_name == 'pull_request' &&
+         github.event.action != 'synchronize' &&
+         github.event.pull_request.head.repo != null &&
+         github.event.pull_request.head.repo.full_name == github.repository) ||
+        (github.event_name == 'issue_comment' &&
+         github.event.issue.pull_request != null &&
+         github.event.issue.state == 'open')
+      )
     concurrency:
-      group: ai-review-${{ github.repository }}-${{ github.event.pull_request.number }}
+      # Namespace by event so a comment-triggered re-review does not cancel
+      # an in-flight pull_request-triggered first review (and vice versa).
+      # NOTE: concurrency expressions are evaluated before the job's env
+      # block materializes, so we inline the PR-number shim instead of
+      # using ${{ env.PR_NUMBER }} (which would resolve to empty here).
+      group: ai-review-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout_minutes || 30 }}
@@ -72,42 +82,136 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
+    env:
+      # Event-shape shim: lift PR identifiers once so steps and the inline
+      # prompt below stay readable.
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+      PR_AUTHOR: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      REPO: ${{ github.repository }}
 
     steps:
-      # Author gating: allow PRs only from users with write or admin on the
-      # calling repo. This replaces the prior team-membership loop and covers
-      # all Automatticians with repo write plus external collaborators
-      # (e.g., Fueled contributors on woocommerce-bookings). Bots are rejected
-      # via github.event.pull_request.user.type.
+      # Trigger validation. issue_comment fires on every comment in the repo;
+      # only proceed if the body matches the bot trigger and the issue is a PR.
+      # COMMENT_BODY comes from event metadata, never from PR HEAD content,
+      # so it is safe to grep against here.
+      - name: Validate trigger
+        id: trigger
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          IS_PR_COMMENT: ${{ github.event.issue.pull_request != null }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "issue_comment" ]; then
+            if [ "$IS_PR_COMMENT" != "true" ]; then
+              echo "Comment is on an issue, not a PR; skipping."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            # Strip CRLF so Windows-clipboard / GitHub-mobile bodies match.
+            # Pattern: line starts with optional whitespace, then @claude or
+            # /claude, then 'review', then end-of-line / whitespace / punctuation.
+            # Permits trailing punctuation (`@claude review.`) and trailing
+            # text (`@claude review please`) but rejects `@claude reviewer` and
+            # markdown prefixes (`## @claude review`, `- @claude review`).
+            CLEAN_BODY=${COMMENT_BODY//$'\r'/}
+            if ! printf '%s\n' "$CLEAN_BODY" | grep -qiE '^[[:space:]]*[@/]claude[[:space:]]+review([[:space:]]|[[:punct:]]|$)'; then
+              echo "Comment did not match @claude review or /claude review trigger; skipping."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      # Defense-in-depth fork rejection. The job-level if: rejects forks on
+      # the pull_request path; issue_comment payloads do not include
+      # head.repo, so we look it up via gh pr view and compare here. exit 1
+      # fails the job before any secret-using model invocation.
+      - name: Reject fork PRs
+        if: steps.trigger.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          set -euo pipefail
+          if [ -n "$PR_HEAD_REPO" ]; then
+            HEAD_REPO="$PR_HEAD_REPO"
+          else
+            HEAD_REPO=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+              --json headRepositoryOwner,headRepository \
+              --jq 'if .headRepository == null or .headRepositoryOwner == null
+                    then "DELETED-OR-UNKNOWN"
+                    else "\(.headRepositoryOwner.login)/\(.headRepository.name)" end')
+          fi
+          if [ "$HEAD_REPO" != "$REPO" ]; then
+            echo "::error::Fork PR rejected. Head repo: $HEAD_REPO, base: $REPO."
+            exit 1
+          fi
+
+      # Author and sender gating: allow runs only when the PR author has
+      # write or admin on the calling repo, AND on issue_comment events,
+      # the comment sender also has write or admin. Both checks are needed
+      # because issue_comment fires from the default branch with secrets in
+      # scope, so any commenter on a PR could otherwise trigger a review.
+      # Bots are rejected via the user.type field.
       #
-      # Note: the permission endpoint returns only admin|write|read|none
-      # (maintain collapses to write, triage to read). The endpoint returns
-      # the highest computed access across direct/team/org/enterprise grants.
+      # The permission endpoint returns only admin|write|read|none (maintain
+      # collapses to write, triage to read). It returns the highest computed
+      # access across direct/team/org/enterprise grants.
       #
       # Docs:
       # - https://docs.github.com/en/rest/collaborators/collaborators#get-repository-permissions-for-a-user
       - name: Check write access
         id: check-team
+        if: steps.trigger.outputs.skip != 'true'
         run: |
-          if [[ "$PR_USER_TYPE" == "Bot" ]]; then
-            echo "Author $PR_USER is a Bot; denying review."
+          set -euo pipefail
+          : "${PR_AUTHOR:?PR_AUTHOR is empty; refusing to query collaborators with empty login}"
+
+          if [[ "$PR_AUTHOR_TYPE" == "Bot" ]]; then
+            echo "Author $PR_AUTHOR is a Bot; denying review."
             echo "is_member=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          PERM=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${PR_USER}/permission" --jq '.permission' || echo "none")
-          case "$PERM" in
-            admin|write)
-              echo "is_member=true" >> "$GITHUB_OUTPUT"
-              ;;
+          PR_PERM=$(gh api "repos/${REPO}/collaborators/${PR_AUTHOR}/permission" --jq '.permission' 2>${RUNNER_TEMP}/gh.err || echo "none")
+          PR_PERM=${PR_PERM:-none}
+          case "$PR_PERM" in
+            admin|write) ;;
             *)
-              echo "Author $PR_USER has permission=$PERM; denying review."
+              echo "Author $PR_AUTHOR has permission=$PR_PERM; denying review."
+              [ -s ${RUNNER_TEMP}/gh.err ] && cat ${RUNNER_TEMP}/gh.err >&2
               echo "is_member=false" >> "$GITHUB_OUTPUT"
+              exit 0
               ;;
           esac
+
+          if [ "$EVENT_NAME" = "issue_comment" ]; then
+            : "${SENDER:?SENDER is empty on issue_comment event}"
+            if [[ "$SENDER_TYPE" == "Bot" ]]; then
+              echo "Comment sender $SENDER is a Bot; denying review."
+              echo "is_member=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            SENDER_PERM=$(gh api "repos/${REPO}/collaborators/${SENDER}/permission" --jq '.permission' 2>${RUNNER_TEMP}/gh.err || echo "none")
+            SENDER_PERM=${SENDER_PERM:-none}
+            case "$SENDER_PERM" in
+              admin|write) ;;
+              *)
+                echo "Comment sender $SENDER has permission=$SENDER_PERM; denying review."
+                [ -s ${RUNNER_TEMP}/gh.err ] && cat ${RUNNER_TEMP}/gh.err >&2
+                echo "is_member=false" >> "$GITHUB_OUTPUT"
+                exit 0
+                ;;
+            esac
+          fi
+
+          echo "is_member=true" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_USER: ${{ github.event.pull_request.user.login }}
-          PR_USER_TYPE: ${{ github.event.pull_request.user.type }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type || github.event.issue.user.type }}
+          SENDER: ${{ github.event.comment.user.login }}
+          SENDER_TYPE: ${{ github.event.comment.user.type }}
 
       # AGENTS.md / CLAUDE.md are bot instructions; skip review if a PR edits them
       # so the bot doesn't review under guidance the PR itself is modifying.
@@ -116,8 +220,6 @@ jobs:
         id: trusted_files
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           FILES=$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)
@@ -261,9 +363,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           BEFORE_SHA: ${{ github.event.before }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
 
       - name: AI Code Review
         if: |
@@ -278,7 +377,7 @@ jobs:
             Review the PR diff for this repository.
 
             REPO: ${{ github.repository }}
-            PR: #${{ github.event.pull_request.number }}
+            PR: #${{ env.PR_NUMBER }}
             REVIEW_TYPE: ${{ steps.followup.outputs.review_type }}
 
             OBJECTIVE
@@ -296,7 +395,7 @@ jobs:
             - Only post inline comments for NEW issues
 
             If REVIEW_TYPE is "tier2" (rebase or no before SHA):
-            - Get the full PR diff using: gh pr diff ${{ github.event.pull_request.number }}
+            - Get the full PR diff using: gh pr diff ${{ env.PR_NUMBER }}
             - Read "${RUNNER_TEMP}/previous_review.txt" for the previous review
             - Read "${RUNNER_TEMP}/author-replies.md" for author replies posted since the previous review
             - Produce a per-issue reconciliation (see PER-ISSUE RECONCILIATION below). Do not re-derive findings from a fresh read of the diff.
@@ -304,7 +403,7 @@ jobs:
 
             If REVIEW_TYPE is "first":
             - This is the first review. Do a full review of the PR diff.
-            - Get the PR diff using: gh pr diff ${{ github.event.pull_request.number }}
+            - Get the PR diff using: gh pr diff ${{ env.PR_NUMBER }}
 
             PER-ISSUE RECONCILIATION (tier1/tier2 only)
             Enumerate EACH prior issue from the previous review. Don't summarize across them. Mark each with one of:
@@ -345,7 +444,7 @@ jobs:
 
             HUMAN REVIEW INVESTIGATION
             Before analyzing the diff, read existing human and bot review comments on this PR:
-               gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews?per_page=100" --paginate
+               gh api "repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}/reviews?per_page=100" --paginate
             For each concern raised by a human or bot reviewer (excluding your own previous AI reviews):
             - Investigate it using the codebase: trace code paths, check how affected functions are used, verify the concern with evidence
             - Include your findings in your review: confirm, refute, or expand on each concern with specific code references
@@ -357,7 +456,7 @@ jobs:
 
             For first reviews:
             1. Fetch ALL existing review comments on this PR:
-               gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments?per_page=100" --paginate
+               gh api "repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}/comments?per_page=100" --paginate
             2. Filter to comments from "claude[bot]" that contain "AI Code Review"
             3. Build a list of already-covered concerns: for each existing comment, note the file path, line number, and the issue described
             4. When you find a potential issue, check your list - if an existing comment ALREADY covers the same concern on the same file (same or nearby lines within 5 lines), SKIP it
@@ -370,7 +469,7 @@ jobs:
             Post ALL comments as a SINGLE review to avoid spamming notifications.
 
             Step 1: Get the latest commit SHA:
-               gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" --jq '.head.sha'
+               gh api "repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}" --jq '.head.sha'
 
             Step 2: Use the Write tool to create a JSON file at ./ai_review_payload.json.
             Replace {{COMMIT_SHA}} with the SHA from Step 1.
@@ -396,7 +495,7 @@ jobs:
             For {{HOUSEKEEPING}}: render the trailing PR-housekeeping block (see PR HOUSEKEEPING below). Empty string if there is nothing to put in it.
 
             Step 3: Submit the review using the file as input:
-               gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" -X POST --input ai_review_payload.json
+               gh api "repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}/reviews" -X POST --input ai_review_payload.json
 
             ALWAYS post a review, even if no issues are found. If the code looks good, submit a review with an empty comments array and a summary like "AI Code Review - No issues found. The changes look good."
 
@@ -504,7 +603,7 @@ jobs:
             6. For each potential issue, check if already covered (skip if so)
             7. Build the {{SUMMARY}} (per-issue reconciliation lines for tier1/tier2, or counts for first) and the {{HOUSEKEEPING}} block (or empty)
             8. Use the Write tool to create ./ai_review_payload.json (include the HTML marker comment, the footer sentinel, and the cheat-sheet block exactly as shown)
-            9. Submit: gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" -X POST --input ai_review_payload.json
+            9. Submit: gh api "repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}/reviews" -X POST --input ai_review_payload.json
 
           claude_args: >
             --model ${{ inputs.model || 'claude-opus-4-6' }}

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -168,13 +168,13 @@ jobs:
             echo "is_member=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          PR_PERM=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${PR_AUTHOR}/permission" --jq '.permission' 2>${RUNNER_TEMP}/gh.err || echo "none")
+          PR_PERM=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${PR_AUTHOR}/permission" --jq '.permission' 2>"${RUNNER_TEMP}/gh.err" || echo "none")
           PR_PERM=${PR_PERM:-none}
           case "$PR_PERM" in
             admin|write) ;;
             *)
               echo "Author $PR_AUTHOR has permission=$PR_PERM; denying review."
-              [ -s ${RUNNER_TEMP}/gh.err ] && cat ${RUNNER_TEMP}/gh.err >&2
+              [ -s "${RUNNER_TEMP}/gh.err" ] && cat "${RUNNER_TEMP}/gh.err" >&2
               echo "is_member=false" >> "$GITHUB_OUTPUT"
               exit 0
               ;;
@@ -187,13 +187,13 @@ jobs:
               echo "is_member=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            SENDER_PERM=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${SENDER}/permission" --jq '.permission' 2>${RUNNER_TEMP}/gh.err || echo "none")
+            SENDER_PERM=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${SENDER}/permission" --jq '.permission' 2>"${RUNNER_TEMP}/gh.err" || echo "none")
             SENDER_PERM=${SENDER_PERM:-none}
             case "$SENDER_PERM" in
               admin|write) ;;
               *)
                 echo "Comment sender $SENDER has permission=$SENDER_PERM; denying review."
-                [ -s ${RUNNER_TEMP}/gh.err ] && cat ${RUNNER_TEMP}/gh.err >&2
+                [ -s "${RUNNER_TEMP}/gh.err" ] && cat "${RUNNER_TEMP}/gh.err" >&2
                 echo "is_member=false" >> "$GITHUB_OUTPUT"
                 exit 0
                 ;;

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -103,14 +103,19 @@ jobs:
               exit 0
             fi
             # Strip CRLF so Windows-clipboard / GitHub-mobile bodies match.
-            # Pattern: line starts with optional whitespace, then @claude or
-            # /claude, then 'review', then end-of-line / whitespace / punctuation.
-            # Permits trailing punctuation (`@claude review.`) and trailing
-            # text (`@claude review please`) but rejects `@claude reviewer` and
-            # markdown prefixes (`## @claude review`, `- @claude review`).
+            # Pattern: line starts with optional whitespace, then `@claude`,
+            # then whitespace, then optional `/`, then `review`, then
+            # end-of-line / whitespace / punctuation.
+            # Accepted: `@claude review`, `@claude /review` (matches the
+            # wp-calypso bot convention), `@claude review.`,
+            # `@claude /review please`.
+            # Rejected: `@claude reviewer` (next char must be space/punct/EOL),
+            # `## @claude review` / `- @claude review` (markdown prefixes are
+            # punct, not space, before `@`), bare `review`, mid-line forms
+            # like `please @claude review this`.
             CLEAN_BODY=${COMMENT_BODY//$'\r'/}
-            if ! printf '%s\n' "$CLEAN_BODY" | grep -qiE '^[[:space:]]*[@/]claude[[:space:]]+review([[:space:]]|[[:punct:]]|$)'; then
-              echo "Comment did not match @claude review or /claude review trigger; skipping."
+            if ! printf '%s\n' "$CLEAN_BODY" | grep -qiE '^[[:space:]]*@claude[[:space:]]+/?review([[:space:]]|[[:punct:]]|$)'; then
+              echo "Comment did not match @claude review or @claude /review trigger; skipping."
               echo "skip=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -97,9 +97,11 @@ jobs:
               echo "skip=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            # Accept `@claude review` and `@claude /review` (line-anchored, optional trailing punctuation).
+            # Accept `@claude review` / `@claude /review`, optionally with one trailing
+            # sentence-ending punct (`.`, `!`, `?`). Reject anything else after the
+            # trigger so a body like `@claude /review;rm -rf` does not match.
             CLEAN_BODY=${COMMENT_BODY//$'\r'/}
-            if ! printf '%s\n' "$CLEAN_BODY" | grep -qiE '^[[:space:]]*@claude[[:space:]]+/?review([[:space:]]|[[:punct:]]|$)'; then
+            if ! printf '%s\n' "$CLEAN_BODY" | grep -qiE '^[[:space:]]*@claude[[:space:]]+/?review[.!?]?[[:space:]]*$'; then
               echo "Comment did not match @claude review or @claude /review trigger; skipping."
               echo "skip=true" >> "$GITHUB_OUTPUT"
               exit 0


### PR DESCRIPTION
## Summary

The reusable AI review workflow now accepts `@claude review` or `@claude /review` PR comments as the re-trigger. Replaces the draft-toggle stopgap from QAO-429.

Auto first-review on open / reopen / ready-for-review unchanged. Pushes still skip. Draft-opened PRs still skip.

## Why

`POST /repos/.../requested_reviewers` silently no-ops for GitHub Apps (verified by direct API testing on an internal test PR), so the originally-proposed "request `claude[bot]` as reviewer" path is dead at the API level. Comment-command is what CodeRabbit, Greptile, Sourcery, Codium, and Gemini actually use in practice. The trigger phrase reuses the existing `@claude addressed` / `@claude rejected:` namespace from the bot's reply cheat sheet, and the `@claude /review` form matches the convention used by `Automattic/wp-calypso`.

## What changes

- New top-level `if:` accepts both `pull_request` and `issue_comment`.
- `Validate trigger` step: line-anchored regex on `comment.body`, strips CRLF, rejects mid-line and markdown-prefixed forms, anchors to EOL so trailing content like `;rm -rf` can't ride along.
- `Reject fork PRs` step using `gh pr view` for `issue_comment` payloads (which lack `head.repo`). Mirrors wp-calypso's pattern.
- `Check write access` now gates PR author AND comment sender (both `admin|write`). Adds `set -euo pipefail` and `${VAR:?}` guards.
- Closed PRs no longer trigger from comments (`issue.state == 'open'`).
- Concurrency group namespaced by event so comment triggers don't cancel in-flight first reviews.

## Draft handling

- PRs opened as draft do not auto-review (gated by `draft == false` on the `pull_request` arm of the `if:`).
- Converting a draft to ready fires `ready_for_review` and triggers a review.
- An explicit `@claude review` comment on a draft PR fires (the comment trigger path is intentional human action; not gated on draft state).

## Trigger forms

| Comment | Fires? |
|---|---|
| `@claude review` | yes |
| `@claude /review` | yes |
| `@claude review.`, `@claude /review!`, `@claude review?` | yes |
| `/claude review` | no |
| `@claude reviewer` | no |
| `@claude review please` (trailing text) | no |
| `@claude /review;rm -rf` (trailing junk) | no |
| `please @claude review this` (mid-line) | no |
| `## @claude review` (markdown header) | no |

## Rollout

Forward-compatible. The 15 unupdated callers continue working unchanged. Two pilot callers (separate PRs in their own repos) will land after this merges. Phase 2 sweeps remaining callers under a follow-up Linear issue.

## Test plan

After pilots land:

- Open ready PR fires first review.
- Open draft PR does not fire.
- Convert draft to ready fires review.
- Push commits, no re-review.
- `@claude review` and `@claude /review` fire re-review.
- `@claude review.` / `@claude /review!` fire re-review.
- `@claude review` on a draft PR fires (explicit human ask).
- `/claude review` does NOT fire.
- `@claude /review;rm -rf` does NOT fire.
- Mid-line `please @claude review this` does NOT fire.
- Trailing-text `@claude review please` does NOT fire.
- Non-write user comment does NOT fire.
- Closed-PR comment does NOT fire.
- Comment on a regular Issue does NOT fire.
- Fork PR comment rejected by the new fork-reject step.

QAO-430. Supersedes QAO-429.