### PR TITLE
ai-review: send per-run telemetry to wpcom

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -594,9 +594,11 @@ jobs:
 
       - name: Send telemetry to wpcom
         if: always() && steps.ai-review.outputs.execution_file != ''
+        continue-on-error: true
         env:
           TELEMETRY_TOKEN: ${{ secrets.AI_REVIEW_TELEMETRY_TOKEN }}
           EXECUTION_FILE: ${{ steps.ai-review.outputs.execution_file }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           T_REPO: ${{ github.repository }}
           T_PR: ${{ github.event.pull_request.number || github.event.issue.number }}
           T_PR_AUTHOR: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
@@ -606,14 +608,33 @@ jobs:
           T_REVIEW_TYPE: ${{ steps.followup.outputs.review_type }}
         shell: bash
         run: |
-          RESULT=$(jq 'map(select(.type == "result")) | last' "$EXECUTION_FILE")
+          if [ ! -s "$EXECUTION_FILE" ]; then
+            echo "telemetry: execution_file missing or empty, skipping"
+            exit 0
+          fi
 
-          SUBTYPE=$(echo "$RESULT" | jq -r '.subtype')
-          case "$SUBTYPE" in
-            success)              OUTCOME="success" ;;
-            error_max_turns)      OUTCOME="error_max_turns" ;;
-            *)                    OUTCOME="is_error" ;;
-          esac
+          if ! RESULT=$(jq 'map(select(.type == "result")) | last' "$EXECUTION_FILE" 2>/dev/null); then
+            echo "telemetry: failed to parse execution_file, skipping"
+            exit 0
+          fi
+
+          if [ "$RESULT" = "null" ] || [ -z "$RESULT" ]; then
+            OUTCOME="no_result"
+            RESULT="null"
+          else
+            SUBTYPE=$(echo "$RESULT" | jq -r '.subtype')
+            case "$SUBTYPE" in
+              success)              OUTCOME="success" ;;
+              error_max_turns)      OUTCOME="error_max_turns" ;;
+              *)                    OUTCOME="is_error" ;;
+            esac
+          fi
+
+          # issue_comment payload is issue-shaped (no pull_request.head), so
+          # head sha is empty on comment-triggered runs. Fall back to gh CLI.
+          if [ -z "$T_PR_HEAD_SHA" ] && [ -n "$T_PR" ]; then
+            T_PR_HEAD_SHA=$(gh pr view "$T_PR" --repo "$T_REPO" --json headRefOid --jq .headRefOid 2>/dev/null || echo "")
+          fi
 
           PAYLOAD=$(echo "$RESULT" | jq \
             --arg source          "woocommerce" \
@@ -649,8 +670,14 @@ jobs:
               ttft_ms:         (.ttft_ms // 0)
             }')
 
-          curl -s -f -X POST \
+          HTTP_STATUS=$(curl -s -o /tmp/telemetry_response -w "%{http_code}" -X POST \
             "https://public-api.wordpress.com/wpcom/v2/ai-review/telemetry" \
             -H "Content-Type: application/json" \
             -H "X-AI-Review-Token: ${TELEMETRY_TOKEN}" \
-            -d "$PAYLOAD"
+            -d "$PAYLOAD")
+          echo "telemetry: HTTP $HTTP_STATUS"
+          if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
+            echo "::warning::Failed to send AI review telemetry (HTTP $HTTP_STATUS)"
+            echo "telemetry response body:"
+            cat /tmp/telemetry_response || true
+          fi

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -615,7 +615,7 @@ jobs:
             *)                    OUTCOME="is_error" ;;
           esac
 
-          PAYLOAD=$(echo "$RESULT" | jq -n --slurpfile r /dev/stdin \
+          PAYLOAD=$(echo "$RESULT" | jq \
             --arg source          "woocommerce" \
             --arg outcome         "$OUTCOME" \
             --arg repo            "$T_REPO" \
@@ -637,16 +637,16 @@ jobs:
               build_url:       $build_url,
               ci_provider:     $ci_provider,
               is_followup:     ($is_followup == "true"),
-              cost_usd:        ($r[0].total_cost_usd // 0),
-              duration:        (($r[0].duration_ms // 0) / 1000),
-              api_duration_ms: ($r[0].duration_api_ms // 0),
-              num_turns:       ($r[0].num_turns // 0),
-              tokens_in:       ($r[0].usage.input_tokens // 0),
-              tokens_out:      ($r[0].usage.output_tokens // 0),
-              cache_read:      ($r[0].usage.cache_read_input_tokens // 0),
-              cache_creation:  ($r[0].usage.cache_creation_input_tokens // 0),
-              session_id:      ($r[0].session_id // ""),
-              ttft_ms:         ($r[0].ttft_ms // 0)
+              cost_usd:        (.total_cost_usd // 0),
+              duration:        ((.duration_ms // 0) / 1000),
+              api_duration_ms: (.duration_api_ms // 0),
+              num_turns:       (.num_turns // 0),
+              tokens_in:       (.usage.input_tokens // 0),
+              tokens_out:      (.usage.output_tokens // 0),
+              cache_read:      (.usage.cache_read_input_tokens // 0),
+              cache_creation:  (.usage.cache_creation_input_tokens // 0),
+              session_id:      (.session_id // ""),
+              ttft_ms:         (.ttft_ms // 0)
             }')
 
           curl -s -f -X POST \

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -16,6 +16,8 @@ on:
     secrets:
       AI_CODE_REVIEW_ANTHROPIC_API_KEY:
         required: true
+      AI_REVIEW_TELEMETRY_TOKEN:
+        required: false
 
 jobs:
   # Caller-org guard. Reject callers outside the allowed orgs before any
@@ -345,6 +347,7 @@ jobs:
           PR_AUTHOR: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
 
       - name: AI Code Review
+        id: ai-review
         if: |
           steps.check-team.outputs.is_member == 'true' &&
           steps.followup.outputs.skip != 'true' &&
@@ -588,3 +591,66 @@ jobs:
           claude_args: >
             --model ${{ inputs.model || 'claude-opus-4-6' }}
             --allowedTools "Read(/home/runner/work/**),Glob,Grep,Write,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git show:*),Bash(git diff:*),Bash(git log:*),Bash(git blame:*),Bash(git rev-parse:*),Bash(git ls-files:*),Bash(git grep:*)"
+
+      - name: Send telemetry to wpcom
+        if: always() && steps.ai-review.outputs.execution_file != ''
+        env:
+          TELEMETRY_TOKEN: ${{ secrets.AI_REVIEW_TELEMETRY_TOKEN }}
+          EXECUTION_FILE: ${{ steps.ai-review.outputs.execution_file }}
+          T_REPO: ${{ github.repository }}
+          T_PR: ${{ github.event.pull_request.number || github.event.issue.number }}
+          T_PR_AUTHOR: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+          T_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          T_MODEL: ${{ inputs.model || 'claude-opus-4-6' }}
+          T_BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          T_REVIEW_TYPE: ${{ steps.followup.outputs.review_type }}
+        shell: bash
+        run: |
+          RESULT=$(jq 'map(select(.type == "result")) | last' "$EXECUTION_FILE")
+
+          SUBTYPE=$(echo "$RESULT" | jq -r '.subtype')
+          case "$SUBTYPE" in
+            success)              OUTCOME="success" ;;
+            error_max_turns)      OUTCOME="error_max_turns" ;;
+            *)                    OUTCOME="is_error" ;;
+          esac
+
+          PAYLOAD=$(echo "$RESULT" | jq -n --slurpfile r /dev/stdin \
+            --arg source          "woocommerce" \
+            --arg outcome         "$OUTCOME" \
+            --arg repo            "$T_REPO" \
+            --arg pr              "$T_PR" \
+            --arg pr_author       "$T_PR_AUTHOR" \
+            --arg pr_head_sha     "$T_PR_HEAD_SHA" \
+            --arg model           "$T_MODEL" \
+            --arg build_url       "$T_BUILD_URL" \
+            --arg ci_provider     "github_actions" \
+            --arg is_followup     "$( [ "$T_REVIEW_TYPE" != "first" ] && echo true || echo false )" \
+            '{
+              source:          $source,
+              outcome:         $outcome,
+              repo:            $repo,
+              pr:              $pr,
+              pr_author:       $pr_author,
+              pr_head_sha:     $pr_head_sha,
+              model:           $model,
+              build_url:       $build_url,
+              ci_provider:     $ci_provider,
+              is_followup:     ($is_followup == "true"),
+              cost_usd:        ($r[0].total_cost_usd // 0),
+              duration:        (($r[0].duration_ms // 0) / 1000),
+              api_duration_ms: ($r[0].duration_api_ms // 0),
+              num_turns:       ($r[0].num_turns // 0),
+              tokens_in:       ($r[0].usage.input_tokens // 0),
+              tokens_out:      ($r[0].usage.output_tokens // 0),
+              cache_read:      ($r[0].usage.cache_read_input_tokens // 0),
+              cache_creation:  ($r[0].usage.cache_creation_input_tokens // 0),
+              session_id:      ($r[0].session_id // ""),
+              ttft_ms:         ($r[0].ttft_ms // 0)
+            }')
+
+          curl -s -f -X POST \
+            "https://public-api.wordpress.com/wpcom/v2/ai-review/telemetry" \
+            -H "Content-Type: application/json" \
+            -H "X-AI-Review-Token: ${TELEMETRY_TOKEN}" \
+            -d "$PAYLOAD"

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -599,6 +599,7 @@ jobs:
           TELEMETRY_TOKEN: ${{ secrets.AI_REVIEW_TELEMETRY_TOKEN }}
           EXECUTION_FILE: ${{ steps.ai-review.outputs.execution_file }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          T_SOURCE: ${{ github.repository_owner }}
           T_REPO: ${{ github.repository }}
           T_PR: ${{ github.event.pull_request.number || github.event.issue.number }}
           T_PR_AUTHOR: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
@@ -637,7 +638,7 @@ jobs:
           fi
 
           PAYLOAD=$(echo "$RESULT" | jq \
-            --arg source          "woocommerce" \
+            --arg source          "$T_SOURCE" \
             --arg outcome         "$OUTCOME" \
             --arg repo            "$T_REPO" \
             --arg pr              "$T_PR" \

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -590,7 +590,7 @@ jobs:
 
           claude_args: >
             --model ${{ inputs.model || 'claude-opus-4-6' }}
-            --allowedTools "Read(/home/runner/work/**),Glob,Grep,Write,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git show:*),Bash(git diff:*),Bash(git log:*),Bash(git blame:*),Bash(git rev-parse:*),Bash(git ls-files:*),Bash(git grep:*)"
+            --allowedTools "Read(/home/runner/work/**),Glob,Grep,Write(./ai_review_payload.json),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git show:*),Bash(git diff:*),Bash(git log:*),Bash(git blame:*),Bash(git rev-parse:*),Bash(git ls-files:*),Bash(git grep:*)"
 
       - name: Send telemetry to wpcom
         if: always() && steps.ai-review.outputs.execution_file != ''


### PR DESCRIPTION
## Proposed Changes

* Add `id: ai-review` to the `AI Code Review` step in `ai-code-review.yml` so a downstream step can read its outputs.
* Append a `Send telemetry to wpcom` step that POSTs cost, duration, token usage, and outcome from each review run to `https://public-api.wordpress.com/wpcom/v2/ai-review/telemetry`.
* Declare `AI_REVIEW_TELEMETRY_TOKEN` as an optional secret on the reusable workflow. Callers without the secret send an empty token and the endpoint rejects.

## Why

We want to track AI review spend and quality across `woocommerce` and `wp-calypso` callers in one place. The wpcom endpoint is the central ingest point; each run sends a single payload describing what it cost, how long it took, whether it succeeded, and whether it was a follow-up review (tier1 / tier2).

The telemetry step is gated on the AI Code Review step actually producing an `execution_file`, so it no-ops on runs that are short-circuited by the org guard, fork-reject, author-permission, or `AGENTS.md` / `CLAUDE.md` guards.

The matching change is going out to `wp-calypso`'s reusable `pr-review.yml`.

## Testing

* Provision `AI_REVIEW_TELEMETRY_TOKEN` as an org / repo secret before merging.
* Open or comment-trigger (`@claude review`) any PR on a caller repo and confirm the `Send telemetry to wpcom` step runs after `AI Code Review`.
* Confirm a row lands on the wpcom dashboard with `source = "woocommerce"`, the right `repo`, `is_followup` matching the trigger, and non-zero `cost_usd` / token counts.
* Negative case: open a fork PR (or a PR that edits `AGENTS.md`) and confirm the telemetry step is skipped along with the review step.
