### PR TITLE
ai-review: handle curl transport errors in telemetry step

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -671,11 +671,15 @@ jobs:
               ttft_ms:         (.ttft_ms // 0)
             }')
 
-          HTTP_STATUS=$(curl -s -o /tmp/telemetry_response -w "%{http_code}" -X POST \
+          if ! HTTP_STATUS=$(curl -s -o /tmp/telemetry_response -w "%{http_code}" -X POST \
             "https://public-api.wordpress.com/wpcom/v2/ai-review/telemetry" \
             -H "Content-Type: application/json" \
             -H "X-AI-Review-Token: ${TELEMETRY_TOKEN}" \
-            -d "$PAYLOAD")
+            -d "$PAYLOAD"); then
+            echo "::warning::Failed to send AI review telemetry (curl transport error)"
+            exit 0
+          fi
+
           echo "telemetry: HTTP $HTTP_STATUS"
           if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
             echo "::warning::Failed to send AI review telemetry (HTTP $HTTP_STATUS)"


### PR DESCRIPTION
## Proposed Changes

* Wrap the telemetry `curl` invocation in `if ! ...; then` so transport-level failures (DNS, TLS, connection refused, timeout) are caught explicitly and emit a single `::warning::` annotation instead of falling through to an arithmetic compare on an empty `HTTP_STATUS`.

## Why

Without this, a curl exit code other than zero (no HTTP response was ever received) would leave `HTTP_STATUS` empty, and the subsequent `[ "$HTTP_STATUS" -lt 200 ]` would print a noisy `integer expression expected` bash error before reaching the existing fall-through. `continue-on-error: true` keeps the job green either way, but the warning path is cleaner and matches Griffith's review on the sibling wp-calypso PR.

Both transport errors and HTTP 4xx/5xx now emit a single, distinct `::warning::` annotation. Telemetry never blocks the AI review job.

## Testing

* No caller change required.
* Next AI review run with the endpoint reachable should behave identically (`telemetry: HTTP 200`).
* To simulate a transport error locally, temporarily change the URL host to something unreachable in a draft branch and run the workflow; the step should emit `::warning::Failed to send AI review telemetry (curl transport error)` and exit 0.