### PR TITLE
ai-review: don't fail the job when skipping trusted-instruction edits

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -206,20 +206,19 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
             gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
               "AI review skipped: this PR modifies \`AGENTS.md\` or \`CLAUDE.md\` files, which the review bot reads as instructions. Edits to these files require human review."
-            exit 1
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout repository
-        if: steps.check-team.outputs.is_member == 'true'
+        if: steps.check-team.outputs.is_member == 'true' && steps.trusted_files.outputs.skip == 'false'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Detect follow-up review
-        if: steps.check-team.outputs.is_member == 'true'
+        if: steps.check-team.outputs.is_member == 'true' && steps.trusted_files.outputs.skip == 'false'
         id: followup
         run: |
           set -uo pipefail


### PR DESCRIPTION
## Why

When a PR edits `AGENTS.md` / `CLAUDE.md`, the AI review intentionally skips, because the bot reads those files as instructions. The skip step ran `exit 1` to halt the run, which painted the whole job red. A red check on an intentional skip is misleading: it looks like a real failure to authors and to anyone watching the caller repos.

This was reported on a real PR (composite-products #1325): the review was correctly skipped, but the Actions job showed as failed.

## What

- Drop the `exit 1` from the "Skip AI review on trusted-instruction file edits" step. It now exits 0 with `skip=true`, and the explanatory skip comment is still posted to the PR.
- Gate the `Checkout repository` and `Detect follow-up review` steps on `steps.trusted_files.outputs.skip == 'false'` so they short-circuit when skipping instead of doing needless `gh api` work.

The `AI Code Review` step was already gated on `trusted_files.outputs.skip == 'false'`, so the safety property is unchanged: a PR that edits the bot's instruction files still never receives an automated review. The job now simply concludes green.

This is a reusable workflow consumed by many caller repos, so the change lands everywhere at once. It is pure step-gating and exit-code logic, with no changes to inputs, secrets, or the caller contract.

## Test plan

- Edit an `AGENTS.md` or `CLAUDE.md` in a PR: expect the skip comment to post and the Actions job to conclude green (steps after the skip show as skipped, not failed).
- Normal PR with no trusted-file edits: expect checkout, follow-up detection, and the review to run as before.
- Non-member / bot author / fork PR: unchanged, still gated off via the existing `is_member` checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)