### PR TITLE
Fix AI code review: bump claude-code-action past Bun crash

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -386,7 +386,7 @@ jobs:
           steps.check-team.outputs.is_member == 'true' &&
           steps.followup.outputs.skip != 'true' &&
           steps.trusted_files.outputs.skip == 'false'
-        uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1.0.107
+        uses: anthropics/claude-code-action@0cb4f3e5e764d2e00407d29b6bf0aa9df0976d88 # v1.0.146
         with:
           anthropic_api_key: ${{ secrets.AI_CODE_REVIEW_ANTHROPIC_API_KEY }}
           prompt: |


### PR DESCRIPTION
## Problem

Automated Claude code reviews stopped posting across repos that use this reusable workflow. The action run shows **green**, but no review comment appears. The job log contains:

```
Internal error: directory mismatch for directory ".../claude-code-action/.../tsconfig.json", fd 4. You don't need to do anything, but this indicates a bug.
```

Despite the "you don't need to do anything" text, **that message is the crash, not a benign warning.** It is a Bun runtime bug ([oven-sh/bun#25730](https://github.com/oven-sh/bun/issues/25730)) triggered by a `--tsconfig-override` flag the action passed to `bun run`. Bun aborts with exit code 1 *before any API call is made*, so the model never runs and no review is posted. The step can still report success. Reported in [claude-code-action#1205](https://github.com/anthropics/claude-code-action/issues/1205), [#1266](https://github.com/anthropics/claude-code-action/issues/1266), [#1295](https://github.com/anthropics/claude-code-action/issues/1295).

## Root cause

This workflow pinned `anthropics/claude-code-action@567fe954` = **v1.0.107** (April 25), which predates the fix. The model in use (`claude-opus-4-6`) is current and not a factor.

## Fix

Anthropic dropped the `--tsconfig-override` flag in **v1.0.143** ([PR #1315](https://github.com/anthropics/claude-code-action/pull/1315)). This bumps the pin to the current latest, **v1.0.146**, which includes the fix:

```diff
- uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1.0.107
+ uses: anthropics/claude-code-action@0cb4f3e5e764d2e00407d29b6bf0aa9df0976d88 # v1.0.146
```

Every caller repo references `@trunk` of this reusable workflow, so this single change unblocks AI review everywhere.

## Verification

- Confirmed the fix commit (drop `--tsconfig-override`) is in v1.0.143 and carried forward through v1.0.146.
- SHA `0cb4f3e5e764d2e00407d29b6bf0aa9df0976d88` verified as the commit for tag v1.0.146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)