### PR TITLE
ai-review: fail loudly when a review is not posted

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -695,15 +695,9 @@ jobs:
             --allowedTools "Read(/home/runner/work/**),Glob,Grep,Write(./ai_review_payload.json),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git show:*),Bash(git diff:*),Bash(git log:*),Bash(git blame:*),Bash(git rev-parse:*),Bash(git ls-files:*),Bash(git grep:*)"
 
       - name: Verify a review was posted
-        # Fail-loudly guard. claude-code-action can report success while posting
-        # nothing (e.g. the Bun crash in older pins that aborted before the API
-        # call). The green status hid that outage across caller repos. If the
-        # step ran but no review carries this commit's marker, fail so the job
-        # goes red and the Slack alert fires.
-        #
-        # Rollout safety: hard-fail only when a caller has forwarded
-        # AI_REVIEW_SLACK_WEBHOOK_URL (opted in). Otherwise warn-only, so merging
-        # this to trunk does not break callers that have not migrated yet.
+        # Fail loudly when claude-code-action reports success but posts no review
+        # (the green-but-silent crash class). Hard-fail only when the caller
+        # forwarded the webhook; otherwise warn-only, so trunk merge stays inert.
         if: ${{ always() && steps.ai-review.outcome == 'success' }}
         shell: bash
         env:
@@ -712,8 +706,7 @@ jobs:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -uo pipefail
-          # Head SHA the model reviewed. Prefer the event payload (stable for the
-          # run); fall back to the API for issue_comment runs, which lack head.sha.
+          # Head SHA from the event; fall back to the API on issue_comment runs.
           HEAD_SHA="$PR_HEAD_SHA"
           if [ -z "$HEAD_SHA" ]; then
             HEAD_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .head.sha 2>/dev/null || true)
@@ -722,18 +715,9 @@ jobs:
             echo "::warning::Could not resolve head SHA (gh api blip); skipping missed-review check."
             exit 0
           fi
-          # Count only a claude[bot] review carrying this commit's marker. The
-          # author filter (nobody else can post as claude[bot]) plus the full
-          # marker prefix stop a forged body from suppressing the alert.
-          #
-          # Accepted weaker guarantee: the check keys on the head SHA, not the run.
-          # claude reviews do not reliably carry the run URL in the body (observed
-          # in only about half of recent caller reviews; the footer link is often
-          # dropped), so correlating to GITHUB_RUN_ID would false-fail valid
-          # reviews. Consequence: a prior run's review for an unchanged head SHA
-          # satisfies the check, so a re-run or re-review on the same SHA that
-          # posts nothing will not alert. The first review for a SHA, which is the
-          # silent-outage case this guards, is still covered.
+          # Match the bot author + this commit's marker. Keyed on head SHA (not the
+          # run: reviews drop the run URL ~half the time), so a no-op re-review on an
+          # unchanged SHA will not alert; the first review for a SHA is covered.
           MARKER="<!-- ai-review: claude-code gha sha:${HEAD_SHA}"
           MATCHES=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" --paginate 2>/dev/null \
             | jq -s --arg m "$MARKER" \
@@ -848,19 +832,13 @@ jobs:
           fi
 
       - name: Alert Slack on missed or failed review
-        # Posts to the channel behind AI_REVIEW_SLACK_WEBHOOK_URL when the job
-        # failed and the caller forwarded the webhook. Gated on HAS_SLACK_WEBHOOK
-        # so a genuine failure in a not-yet-migrated caller does not run this with
-        # an empty webhook.
+        # Fires only when the job failed and the caller forwarded a webhook.
         if: ${{ failure() && env.HAS_SLACK_WEBHOOK == 'true' }}
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           webhook: ${{ secrets.AI_REVIEW_SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           errors: true
-          # All interpolated values below are URLs and numeric ids (no free text),
-          # so the inline JSON is safe. If a free-text field is ever added, build
-          # the payload with jq -n --arg instead of string interpolation.
           payload: |
             {
               "text": "AI code review job failed (a review may not have been posted). PR: ${{ github.server_url }}/${{ github.repository }}/pull/${{ env.PR_NUMBER }} Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -722,23 +722,28 @@ jobs:
             echo "::warning::Could not resolve head SHA (gh api blip); skipping missed-review check."
             exit 0
           fi
-          # Count only a claude[bot] review for THIS run: the body must carry both
-          # this commit's marker and this run's URL. The author filter (nobody
-          # else can post as claude[bot]) plus the full marker prefix stop a forged
-          # body from suppressing the alert; requiring this run's id stops a prior
-          # run's review for an unchanged head SHA from masking a re-run or
-          # re-review that itself posted nothing.
+          # Count only a claude[bot] review carrying this commit's marker. The
+          # author filter (nobody else can post as claude[bot]) plus the full
+          # marker prefix stop a forged body from suppressing the alert.
+          #
+          # Accepted weaker guarantee: the check keys on the head SHA, not the run.
+          # claude reviews do not reliably carry the run URL in the body (observed
+          # in only about half of recent caller reviews; the footer link is often
+          # dropped), so correlating to GITHUB_RUN_ID would false-fail valid
+          # reviews. Consequence: a prior run's review for an unchanged head SHA
+          # satisfies the check, so a re-run or re-review on the same SHA that
+          # posts nothing will not alert. The first review for a SHA, which is the
+          # silent-outage case this guards, is still covered.
           MARKER="<!-- ai-review: claude-code gha sha:${HEAD_SHA}"
-          RUN_NEEDLE="actions/runs/${GITHUB_RUN_ID}"
           MATCHES=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" --paginate 2>/dev/null \
-            | jq -s --arg m "$MARKER" --arg r "$RUN_NEEDLE" \
-                '[ .[][] | select(.user.login == "claude[bot]") | select((.body | contains($m)) and (.body | contains($r))) ] | length' 2>/dev/null || true)
+            | jq -s --arg m "$MARKER" \
+                '[ .[][] | select(.user.login == "claude[bot]") | select(.body | contains($m)) ] | length' 2>/dev/null || true)
           if [ -z "$MATCHES" ]; then
             echo "::warning::Could not fetch or parse reviews (gh api blip); skipping missed-review check."
             exit 0
           fi
           if [ "$MATCHES" -gt 0 ]; then
-            echo "AI review present for ${HEAD_SHA} (run ${GITHUB_RUN_ID})."
+            echo "AI review present for ${HEAD_SHA}."
             exit 0
           fi
           echo "::error::AI Code Review reported success but posted no review for ${HEAD_SHA} (run ${GITHUB_RUN_ID})."

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -709,10 +709,29 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           WEBHOOK: ${{ secrets.AI_REVIEW_SLACK_WEBHOOK_URL }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          HEAD_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .head.sha)
-          if gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" --paginate \
-               --jq '.[].body' | grep -qF "gha sha:${HEAD_SHA}"; then
+          set -uo pipefail
+          # Head SHA the model reviewed. Prefer the event payload (stable for the
+          # run); fall back to the API for issue_comment runs, which lack head.sha.
+          HEAD_SHA="$PR_HEAD_SHA"
+          if [ -z "$HEAD_SHA" ]; then
+            HEAD_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .head.sha 2>/dev/null || true)
+          fi
+          if [ -z "$HEAD_SHA" ]; then
+            echo "::warning::Could not resolve head SHA (gh api blip); skipping missed-review check."
+            exit 0
+          fi
+          # Count only a review by the AI reviewer bot that carries this commit's
+          # full marker. The author filter (nobody else can post as claude[bot])
+          # plus the exact HTML-comment prefix stop anyone from suppressing the
+          # alert by pasting the public marker string into their own review.
+          if ! REVIEWS=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" --paginate \
+                --jq '.[] | select(.user.login == "claude[bot]") | .body' 2>/dev/null); then
+            echo "::warning::Could not fetch reviews (gh api blip); skipping missed-review check."
+            exit 0
+          fi
+          if printf '%s' "$REVIEWS" | grep -qF "<!-- ai-review: claude-code gha sha:${HEAD_SHA}"; then
             echo "AI review present for ${HEAD_SHA}."
             exit 0
           fi
@@ -827,7 +846,8 @@ jobs:
         with:
           webhook: ${{ secrets.AI_REVIEW_SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
+          errors: true
           payload: |
             {
-              "text": "AI code review failed or posted no review. PR: ${{ github.server_url }}/${{ github.repository }}/pull/${{ env.PR_NUMBER }} Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": "AI code review job failed (a review may not have been posted). PR: ${{ github.server_url }}/${{ github.repository }}/pull/${{ env.PR_NUMBER }} Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -722,17 +722,23 @@ jobs:
             echo "::warning::Could not resolve head SHA (gh api blip); skipping missed-review check."
             exit 0
           fi
-          # Count only a review by the AI reviewer bot that carries this commit's
-          # full marker. The author filter (nobody else can post as claude[bot])
-          # plus the exact HTML-comment prefix stop anyone from suppressing the
-          # alert by pasting the public marker string into their own review.
-          if ! REVIEWS=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" --paginate \
-                --jq '.[] | select(.user.login == "claude[bot]") | .body' 2>/dev/null); then
-            echo "::warning::Could not fetch reviews (gh api blip); skipping missed-review check."
+          # Count only a claude[bot] review for THIS run: the body must carry both
+          # this commit's marker and this run's URL. The author filter (nobody
+          # else can post as claude[bot]) plus the full marker prefix stop a forged
+          # body from suppressing the alert; requiring this run's id stops a prior
+          # run's review for an unchanged head SHA from masking a re-run or
+          # re-review that itself posted nothing.
+          MARKER="<!-- ai-review: claude-code gha sha:${HEAD_SHA}"
+          RUN_NEEDLE="actions/runs/${GITHUB_RUN_ID}"
+          MATCHES=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" --paginate 2>/dev/null \
+            | jq -s --arg m "$MARKER" --arg r "$RUN_NEEDLE" \
+                '[ .[][] | select(.user.login == "claude[bot]") | select((.body | contains($m)) and (.body | contains($r))) ] | length' 2>/dev/null || true)
+          if [ -z "$MATCHES" ]; then
+            echo "::warning::Could not fetch or parse reviews (gh api blip); skipping missed-review check."
             exit 0
           fi
-          if printf '%s' "$REVIEWS" | grep -qF "<!-- ai-review: claude-code gha sha:${HEAD_SHA}"; then
-            echo "AI review present for ${HEAD_SHA}."
+          if [ "$MATCHES" -gt 0 ]; then
+            echo "AI review present for ${HEAD_SHA} (run ${GITHUB_RUN_ID})."
             exit 0
           fi
           echo "::error::AI Code Review reported success but posted no review for ${HEAD_SHA} (run ${GITHUB_RUN_ID})."
@@ -847,6 +853,9 @@ jobs:
           webhook: ${{ secrets.AI_REVIEW_SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           errors: true
+          # All interpolated values below are URLs and numeric ids (no free text),
+          # so the inline JSON is safe. If a free-text field is ever added, build
+          # the payload with jq -n --arg instead of string interpolation.
           payload: |
             {
               "text": "AI code review job failed (a review may not have been posted). PR: ${{ github.server_url }}/${{ github.repository }}/pull/${{ env.PR_NUMBER }} Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -18,6 +18,8 @@ on:
         required: true
       AI_REVIEW_TELEMETRY_TOKEN:
         required: false
+      AI_REVIEW_SLACK_WEBHOOK_URL:
+        required: false
 
 jobs:
   # Caller-org guard. Reject callers outside the allowed orgs before any
@@ -91,6 +93,7 @@ jobs:
     # to the 21,000-char max-expression-length limit.
     env:
       PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+      HAS_SLACK_WEBHOOK: ${{ secrets.AI_REVIEW_SLACK_WEBHOOK_URL != '' }}
 
     steps:
       # Gate issue_comment runs to PR comments matching the bot trigger.
@@ -691,6 +694,34 @@ jobs:
             --model ${{ inputs.model || 'claude-opus-4-6' }}
             --allowedTools "Read(/home/runner/work/**),Glob,Grep,Write(./ai_review_payload.json),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git show:*),Bash(git diff:*),Bash(git log:*),Bash(git blame:*),Bash(git rev-parse:*),Bash(git ls-files:*),Bash(git grep:*)"
 
+      - name: Verify a review was posted
+        # Fail-loudly guard. claude-code-action can report success while posting
+        # nothing (e.g. the Bun crash in older pins that aborted before the API
+        # call). The green status hid that outage across caller repos. If the
+        # step ran but no review carries this commit's marker, fail so the job
+        # goes red and the Slack alert fires.
+        #
+        # Rollout safety: hard-fail only when a caller has forwarded
+        # AI_REVIEW_SLACK_WEBHOOK_URL (opted in). Otherwise warn-only, so merging
+        # this to trunk does not break callers that have not migrated yet.
+        if: ${{ always() && steps.ai-review.outcome == 'success' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WEBHOOK: ${{ secrets.AI_REVIEW_SLACK_WEBHOOK_URL }}
+        run: |
+          HEAD_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .head.sha)
+          if gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" --paginate \
+               --jq '.[].body' | grep -qF "gha sha:${HEAD_SHA}"; then
+            echo "AI review present for ${HEAD_SHA}."
+            exit 0
+          fi
+          echo "::error::AI Code Review reported success but posted no review for ${HEAD_SHA} (run ${GITHUB_RUN_ID})."
+          if [ -n "${WEBHOOK}" ]; then
+            exit 1
+          fi
+          echo "::warning::Detection in warn-only mode (no AI_REVIEW_SLACK_WEBHOOK_URL forwarded); not failing the job."
+
       - name: Send telemetry to wpcom
         if: always() && steps.ai-review.outputs.execution_file != ''
         continue-on-error: true
@@ -785,3 +816,18 @@ jobs:
             echo "telemetry response body:"
             cat /tmp/telemetry_response || true
           fi
+
+      - name: Alert Slack on missed or failed review
+        # Posts to the channel behind AI_REVIEW_SLACK_WEBHOOK_URL when the job
+        # failed and the caller forwarded the webhook. Gated on HAS_SLACK_WEBHOOK
+        # so a genuine failure in a not-yet-migrated caller does not run this with
+        # an empty webhook.
+        if: ${{ failure() && env.HAS_SLACK_WEBHOOK == 'true' }}
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          webhook: ${{ secrets.AI_REVIEW_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "AI code review failed or posted no review. PR: ${{ github.server_url }}/${{ github.repository }}/pull/${{ env.PR_NUMBER }} Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }


### PR DESCRIPTION
## What

A fail-loudly net for the reusable AI code review so a silent outage cannot hide behind a green check.

- After a successful `claude-code-action` run, a step checks that a `claude[bot]` review carrying this commit's marker exists. If the action reported success but posted nothing (the old Bun crash did this), the job fails.
- On failure, a step posts to the channel behind `AI_REVIEW_SLACK_WEBHOOK_URL`.

Detection is warn-only unless the caller forwards `AI_REVIEW_SLACK_WEBHOOK_URL`, so merging to trunk is inert until each caller opts in.

## Verified

GHA behavior confirmed against the docs and a live test, not assumed: `secrets` resolves in job-level `env`; `env` is readable in a step `if` (`secrets` is not, hence the `HAS_SLACK_WEBHOOK` indirection); `failure()` fires past the `continue-on-error` telemetry step; `outcome == 'success'` gates detection. All actions are SHA-pinned (slack v2.0.0, checkout v4.3.1, claude-code-action v1.0.146); existing job permissions cover the new steps.

Expert-panel reviewed. Detection filters to the `claude[bot]` author and the full marker, so an arbitrary review body cannot suppress the alert. It keys on head SHA, not the run URL, because reviews carry the run URL only about half the time.

## Test plan

On `automatewoo` with the webhook forwarded: forced a missed review, the job went red and the Slack alert posted to the qualityops-alerts channel. Warn-only confirmed without the webhook. Happy path will be smoke-tested on trunk after merge.

`AI_REVIEW_SLACK_WEBHOOK_URL` is org-scoped: provision in woocommerce and mailpoet. Tracking: QAO-558.
