### PR TITLE
ai-review: skip review on workflow-file edits; prettier Slack alert

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -205,7 +205,10 @@ jobs:
 
       # AGENTS.md / CLAUDE.md are bot instructions; skip review if a PR edits them
       # so the bot doesn't review under guidance the PR itself is modifying.
-      - name: Skip AI review on trusted-instruction file edits
+      # Also skip if the PR edits the AI review workflow file: the app token
+      # exchange (OIDC) rejects a workflow that differs from the default branch,
+      # so the review cannot run on those PRs anyway.
+      - name: Skip AI review on trusted-instruction or workflow-file edits
         if: steps.check-team.outputs.is_member == 'true'
         id: trusted_files
         env:
@@ -219,6 +222,10 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
             gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
               "AI review skipped: this PR modifies \`AGENTS.md\` or \`CLAUDE.md\` files, which the review bot reads as instructions. Edits to these files require human review."
+          elif printf '%s\n' "$FILES" | grep -qE '^\.github/workflows/ai-code-review\.yml$'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
+              "AI review skipped: this PR changes the AI review workflow file, which the review app cannot mint a token for (the OIDC token exchange requires the workflow to match the default branch)."
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
@@ -841,5 +848,24 @@ jobs:
           errors: true
           payload: |
             {
-              "text": "AI code review job failed (a review may not have been posted). PR: ${{ github.server_url }}/${{ github.repository }}/pull/${{ env.PR_NUMBER }} Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": "AI code review job failed on ${{ github.repository }} PR #${{ env.PR_NUMBER }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": { "type": "plain_text", "text": ":rotating_light: AI code review job failed", "emoji": true }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    { "type": "mrkdwn", "text": "*Repo*\n${{ github.repository }}" },
+                    { "type": "mrkdwn", "text": "*Pull request*\n<${{ github.server_url }}/${{ github.repository }}/pull/${{ env.PR_NUMBER }}|#${{ env.PR_NUMBER }}>" }
+                  ]
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    { "type": "mrkdwn", "text": "A review may not have been posted. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>" }
+                  ]
+                }
+              ]
             }


### PR DESCRIPTION
## What

Two changes to the reusable AI review workflow.

**1. Skip review on AI-review-workflow edits.** A PR that changes `.github/workflows/ai-code-review.yml` cannot be reviewed: the app OIDC token exchange returns `401 Workflow validation failed` because the PR-branch workflow differs from the default branch (an anti-tampering guard). Today such PRs run, fail at the token step, and fire a false "job failed" Slack alert. This skips them in the existing trusted-instruction gate, alongside `AGENTS.md`/`CLAUDE.md`. A PR touching other workflow files (e.g. `build.yml`) still reviews normally.

**2. Prettier Slack alert (Block Kit).** Replaces the one-line URL blob with a header, repo and PR fields, and a workflow-run link, plus a `text` fallback for notifications. Only constrained values (repo, PR number, run id, server url) are interpolated, so the inline JSON stays injection-safe.

## Why now

The mailpoet caller forward PRs each fired a false alert from their own runs. Change 1 stops the upcoming 14 woocommerce forward PRs from doing the same.

## Notes

- This PR edits the workflow file, so if woocommerce/.github reviews its own PRs it will fire one expected alert until merge. After merge, change 1 prevents it.
- Validated locally: YAML parses, the Slack payload is valid Block Kit with a text fallback.

Ref QAO-558.
