### PR TITLE
ai-review: bump claude-code-action v1.0.146 -> v1.0.159

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -402,7 +402,7 @@ jobs:
           steps.check-team.outputs.is_member == 'true' &&
           steps.followup.outputs.skip != 'true' &&
           steps.trusted_files.outputs.skip == 'false'
-        uses: anthropics/claude-code-action@0cb4f3e5e764d2e00407d29b6bf0aa9df0976d88 # v1.0.146
+        uses: anthropics/claude-code-action@80b31826338489861333dc17217865dfe8085cdc # v1.0.155
         with:
           anthropic_api_key: ${{ secrets.AI_CODE_REVIEW_ANTHROPIC_API_KEY }}
           prompt: |

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -402,7 +402,7 @@ jobs:
           steps.check-team.outputs.is_member == 'true' &&
           steps.followup.outputs.skip != 'true' &&
           steps.trusted_files.outputs.skip == 'false'
-        uses: anthropics/claude-code-action@80b31826338489861333dc17217865dfe8085cdc # v1.0.155
+        uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1.0.159
         with:
           anthropic_api_key: ${{ secrets.AI_CODE_REVIEW_ANTHROPIC_API_KEY }}
           prompt: |


### PR DESCRIPTION
Bumps `anthropics/claude-code-action` from v1.0.146 to **v1.0.159** (latest, SHA-pinned).

Context: chasing intermittent runs that report success but post no review, and runs that grind to the job timeout (QAO-568). The action installs the Claude Code CLI itself; we do not pin the CLI version. This picks up the newest action release in case it changes CLI/loop behavior.

Ref QAO-568.
