### PR TITLE
ai-review: add 25-min step timeout so runaways fail loudly

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -398,6 +398,11 @@ jobs:
 
       - name: AI Code Review
         id: ai-review
+        # Step-level cap below the 30-min job timeout. A runaway model hits this
+        # and FAILS the step (a step timeout is a failure, not a job cancel), so
+        # the failure() alert fires, with job budget left to send it. A bare job
+        # timeout would mark the job cancelled, which the alert gate skips.
+        timeout-minutes: 25
         if: |
           steps.check-team.outputs.is_member == 'true' &&
           steps.followup.outputs.skip != 'true' &&


### PR DESCRIPTION
## Problem

A review run where the model grinds to the 30-minute job timeout (e.g. woocommerce-bookings#4281, a large PR) gets marked `cancelled` by GitHub. The Slack alert is gated on `failure() && HAS_SLACK_WEBHOOK`, and `cancelled() != failure()`, so the alert is skipped. The worst failure (a ~30-min, multi-dollar runaway that posts no review) is currently silent in the alerts channel.

## Fix

Add `timeout-minutes: 25` to the `AI Code Review` step, under the 30-min job timeout. A step that exceeds its timeout fails (a step timeout is a failure, not a job cancel), so the existing `failure()` alert fires. Bonus: it fails 5 minutes sooner, with job budget left to actually send the alert.

## To verify after merge

Re-fire a review on bookings#4281 (the reliable runaway repro). Expected: the step fails at ~25 min, the job goes red, and the Block Kit alert posts to #qualityops-alerts. Confirms a step timeout surfaces as `failure()` and trips the gate.

Ref QAO-568.
