### PR TITLE
ai-review: upload execution transcript artifact (temporary, QAO-568 capture)

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -712,8 +712,11 @@ jobs:
             --model ${{ inputs.model || 'claude-opus-4-6' }}
             --allowedTools "Read(/home/runner/work/**),Glob,Grep,Write(./ai_review_payload.json),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git show:*),Bash(git diff:*),Bash(git log:*),Bash(git blame:*),Bash(git rev-parse:*),Bash(git ls-files:*),Bash(git grep:*)"
 
-      # DEBUG BRANCH ONLY: keep the full execution transcript (case A: success but
-      # no post). Empty on a runaway that gets killed before the file is written.
+      # TEMPORARY (QAO-568): keep the full execution transcript so we can read why
+      # a run reports success but posts no review. Must live on trunk (a debug
+      # branch fails the OIDC token exchange, which requires the reusable workflow
+      # to match the default branch). Empty on a runaway killed before the file is
+      # written. Revert once a transcript is captured.
       - name: Upload execution transcript (debug)
         if: always() && steps.ai-review.outputs.execution_file != ''
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -410,9 +410,6 @@ jobs:
         uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1.0.159
         with:
           anthropic_api_key: ${{ secrets.AI_CODE_REVIEW_ANTHROPIC_API_KEY }}
-          # DEBUG BRANCH ONLY: stream the full agent transcript to the run log so a
-          # runaway (killed before execution_file is written) is still captured.
-          show_full_output: true
           prompt: |
             You are a senior code reviewer for WooCommerce extensions.
             Review the PR diff for this repository.

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -410,6 +410,9 @@ jobs:
         uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1.0.159
         with:
           anthropic_api_key: ${{ secrets.AI_CODE_REVIEW_ANTHROPIC_API_KEY }}
+          # DEBUG BRANCH ONLY: stream the full agent transcript to the run log so a
+          # runaway (killed before execution_file is written) is still captured.
+          show_full_output: true
           prompt: |
             You are a senior code reviewer for WooCommerce extensions.
             Review the PR diff for this repository.
@@ -711,6 +714,16 @@ jobs:
           claude_args: >
             --model ${{ inputs.model || 'claude-opus-4-6' }}
             --allowedTools "Read(/home/runner/work/**),Glob,Grep,Write(./ai_review_payload.json),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git show:*),Bash(git diff:*),Bash(git log:*),Bash(git blame:*),Bash(git rev-parse:*),Bash(git ls-files:*),Bash(git grep:*)"
+
+      # DEBUG BRANCH ONLY: keep the full execution transcript (case A: success but
+      # no post). Empty on a runaway that gets killed before the file is written.
+      - name: Upload execution transcript (debug)
+        if: always() && steps.ai-review.outputs.execution_file != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ai-review-execution-${{ github.run_id }}
+          path: ${{ steps.ai-review.outputs.execution_file }}
+          retention-days: 1
 
       - name: Verify a review was posted
         # Fail loudly when claude-code-action reports success but posts no review


### PR DESCRIPTION
## Why

Temporary instrumentation for QAO-568. We cannot explain the "reports success but posts no review" failures because the agent transcript (`execution_file`) is written to the runner, read by the telemetry step, then destroyed with the runner. Nothing keeps it. The GHA log has only the init and a truncated result, no turn-by-turn.

## What

Add one step that uploads `steps.ai-review.outputs.execution_file` as a 1-day artifact on completed runs. Then we download it, read the full transcript (did the model call the reviews POST? did it error? did it never try?), and find the root cause.

- Artifact only, no `show_full_output` log dump (that would stream every caller's transcript into logs org-wide).
- Empty on a killed runaway (the file is not written before the timeout). Expected; this targets the success-but-no-post case.
- Private repos, so artifacts are collaborator-only. retention-days: 1. Deletable immediately via the API after download.

## Plan

Merge, let it run or re-fire a couple of reviews on the repos that flake (bookings, gateway-stripe), grab the artifact from a no-post run, then revert this. Short-lived on trunk.

Ref QAO-568.
