### PR TITLE
Revert ai-review debug artifact (QAO-568 capture done)

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -712,19 +712,6 @@ jobs:
             --model ${{ inputs.model || 'claude-opus-4-6' }}
             --allowedTools "Read(/home/runner/work/**),Glob,Grep,Write(./ai_review_payload.json),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git show:*),Bash(git diff:*),Bash(git log:*),Bash(git blame:*),Bash(git rev-parse:*),Bash(git ls-files:*),Bash(git grep:*)"
 
-      # TEMPORARY (QAO-568): keep the full execution transcript so we can read why
-      # a run reports success but posts no review. Must live on trunk (a debug
-      # branch fails the OIDC token exchange, which requires the reusable workflow
-      # to match the default branch). Empty on a runaway killed before the file is
-      # written. Revert once a transcript is captured.
-      - name: Upload execution transcript (debug)
-        if: always() && steps.ai-review.outputs.execution_file != ''
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: ai-review-execution-${{ github.run_id }}
-          path: ${{ steps.ai-review.outputs.execution_file }}
-          retention-days: 1
-
       - name: Verify a review was posted
         # Fail loudly when claude-code-action reports success but posts no review
         # (the green-but-silent crash class). Hard-fail only when the caller


### PR DESCRIPTION
Removes the temporary execution-transcript artifact step added in https://github.com/woocommerce/.github/pull/38 for the QAO-568 root-cause capture.

The transcript was captured. Even a run that posted (bookings#4330) shows the model burning ~30+ tool calls fighting the allowlist: it cannot read `${RUNNER_TEMP}/review_context.txt` (env, printenv, cat, python3, node all denied) and cannot write the payload via the allowed path, so it thrashes through its turn budget and only posts via a `gh api -f` workaround. On unlucky runs it exhausts turns first and posts nothing.

Findings are in QAO-568. The debug instrumentation is no longer needed on trunk. Merge to remove it.

Validated: YAML parses, actionlint clean.
