### PR TITLE
ai-review: re-enable execution-transcript artifact for QAO-568 diagnosis

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -793,6 +793,19 @@ jobs:
             --model ${{ inputs.model || 'claude-opus-4-6' }}
             --allowedTools "Read(.ai-review/**),Glob,Grep,Write(./ai_review_payload.json),Bash(bash .ai-review/finalize.sh:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git show:*),Bash(git diff:*),Bash(git log:*),Bash(git blame:*),Bash(git rev-parse:*),Bash(git ls-files:*),Bash(git grep:*)"
 
+      # TEMPORARY (QAO-568): keep the full execution transcript so we can read why
+      # a run reports success but posts no review. Must live on trunk (a debug
+      # branch fails the OIDC token exchange, which requires the reusable workflow
+      # to match the default branch). Empty on a runaway killed before the file is
+      # written. Revert once a transcript is captured.
+      - name: Upload execution transcript (debug)
+        if: always() && steps.ai-review.outputs.execution_file != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ai-review-execution-${{ github.run_id }}
+          path: ${{ steps.ai-review.outputs.execution_file }}
+          retention-days: 1
+
       - name: Verify a review was posted
         # Fail loudly when claude-code-action reports success but posts no review
         # (the green-but-silent crash class). Hard-fail only when the caller


### PR DESCRIPTION
Reverts #39, which had removed the debug upload-artifact step.

Related: QAO-568, QAO-562.