### PR TITLE
ai-review: pin the Claude Code CLI version (QAO-588)

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -524,7 +524,14 @@ jobs:
           CLI_VERSION: 2.1.195
         run: |
           set -euo pipefail
-          npm install -g "@anthropic-ai/claude-code@${CLI_VERSION}"
+          # SECURITY: this step runs inside the PR checkout (it must stay after
+          # the followup gate, whose output only exists post-checkout), and npm
+          # reads ./.npmrc from the working directory — a PR could commit one
+          # that repoints the @anthropic-ai scope at a rogue registry. Install
+          # from RUNNER_TEMP and force the registry so the checkout can't
+          # influence what binary we hand ANTHROPIC_API_KEY to.
+          cd "$RUNNER_TEMP"
+          npm install -g --@anthropic-ai:registry=https://registry.npmjs.org/ "@anthropic-ai/claude-code@${CLI_VERSION}"
           CLAUDE_BIN=$(command -v claude)
           echo "path=${CLAUDE_BIN}" >> "$GITHUB_OUTPUT"
           echo "Pinned Claude Code CLI ${CLI_VERSION} at ${CLAUDE_BIN}"

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -504,6 +504,32 @@ jobs:
           gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" -X POST --input ai_review_payload.final.json
           FINALIZE
 
+      # Pin the Claude Code CLI so a silent upstream CLI release cannot change
+      # tool behaviour mid-flight. In Jun 2026 an unpinned CLI update changed the
+      # Write-tool path scoping and silently broke payload writes across repos.
+      # The claude-code-action installs the LATEST CLI at runtime unless given an
+      # executable; path_to_claude_code_executable (below) skips that auto-install.
+      #
+      # HOW TO BUMP: change CLI_VERSION below in its own PR. Confirm the version is
+      # live on npm (npm view @anthropic-ai/claude-code@<v> version) and that a
+      # review still posts, then merge. Keep it reasonably current — the action
+      # warns that an older CLI can lag new action features.
+      - name: Install pinned Claude Code CLI
+        id: pin-cli
+        if: |
+          steps.check-team.outputs.is_member == 'true' &&
+          steps.followup.outputs.skip != 'true' &&
+          steps.trusted_files.outputs.skip == 'false'
+        env:
+          CLI_VERSION: 2.1.195
+        run: |
+          set -euo pipefail
+          npm install -g "@anthropic-ai/claude-code@${CLI_VERSION}"
+          CLAUDE_BIN=$(command -v claude)
+          echo "path=${CLAUDE_BIN}" >> "$GITHUB_OUTPUT"
+          echo "Pinned Claude Code CLI ${CLI_VERSION} at ${CLAUDE_BIN}"
+          "$CLAUDE_BIN" --version
+
       - name: AI Code Review
         id: ai-review
         # Step-level cap below the 30-min job timeout. A runaway model hits this
@@ -521,6 +547,8 @@ jobs:
         uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1.0.159
         with:
           anthropic_api_key: ${{ secrets.AI_CODE_REVIEW_ANTHROPIC_API_KEY }}
+          # Pinned CLI from the step above; skips the action's runtime auto-install.
+          path_to_claude_code_executable: ${{ steps.pin-cli.outputs.path }}
           prompt: |
             You are a senior code reviewer for WooCommerce extensions.
             Review the PR diff for this repository.


### PR DESCRIPTION
## Problem

The AI review workflow pins `claude-code-action` by SHA, but the action installs the **latest** Claude Code CLI at runtime. The CLI is therefore unpinned and drifts whenever a new version is published.

On 2026-06-29/30 a silent CLI update changed how the Write tool derives its path scope (it now reads the `Edit(...)` permission specifier, not `Write(...)`). The allowlist rule silently stopped matching, the model could not save its review payload, and reviews across multiple extension repos (gateway-stripe, composite-products, product-addons, subscriptions, bookings, product-bundles) either posted nothing or burned the timeout retrying the denied write. That symptom was patched in #48 by switching the rule to `Edit(ai_review_payload.json)`.

The root exposure remained: an unpinned CLI can break the pipeline again on the next silent release, with no warning.

## What changed

- **New step `Install pinned Claude Code CLI`** installs `@anthropic-ai/claude-code@2.1.195` (a current, confirmed-working version) and exports its path. Gated by the same `if:` as the review step, so skipped runs stay fast.
- **New action input `path_to_claude_code_executable`** points the action at the pinned executable. Per the action's `action.yml`, when this input is set the action **skips its own runtime auto-install** and uses the provided binary.

CLI upgrades now happen via an explicit, reviewable PR — bump `CLI_VERSION` in the workflow — instead of silently at runtime. A `HOW TO BUMP` note is inline in the workflow.

## Reviewer notes

- `node`/`npm` are preinstalled on `ubuntu-latest`; no `setup-node` needed.
- The action documents a warning that an older CLI can lag new action features — hence pinning to a recent version and keeping it reasonably current, not freezing forever.
- The execution-transcript artifact step is intentionally left live — it's the early-warning for this class of regression — until the pin has proven itself.
- No change to `claude_args`, the allowlist, or the `Edit(ai_review_payload.json)` rule from #48.
- This PR edits the workflow file, so the review bot will **not** self-review it (the workflow's own OIDC-token guard skips workflow-file-editing PRs). Validate on the first review run in a caller repo after merge: the install step logs the pinned version + `claude --version`, and the `Verify a review was posted` step passes.