### PR TITLE
ci: set timeout-minutes on the guard job

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -47,6 +47,7 @@ jobs:
   # - Pull request events on forks: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target
   guard:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions: {}
     steps:
       - name: Reject callers outside allowed orgs


### PR DESCRIPTION
Set a job timeout so a stuck run stops in minutes, not after six hours.

| Job | Median, 30 days | Max, 30 days | `timeout-minutes` |
| -- | -- | -- | -- |
| `guard` | 3s | 5s | 5 |

Part of TESTOPS-272